### PR TITLE
Add Zenodo and citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,41 @@
+{
+    "title": "hextraj: hex labelling of trajectory data",
+    "description": "<p>hextraj maps longitude/latitude positions onto a projected hexagonal grid and provides tools for aggregating trajectory data over hex cells and for computing origin-destination connectivity between them.</p><p>It operates on NumPy, pandas, xarray, and dask objects, so the same code runs on a single array or on datasets larger than memory. Core entry points are <code>HexProj</code> for grid construction and labelling, <code>hex_counts</code> for density aggregation, <code>hex_connectivity</code> and <code>hex_connectivity_dask</code> for origin-destination matrices, and <code>hex_connectivity_power</code> for multi-generation transport probabilities.</p><p>Documentation: <a href=\"https://willirath.github.io/hextraj/\">https://willirath.github.io/hextraj/</a></p>",
+    "upload_type": "software",
+    "access_right": "open",
+    "license": "mit",
+    "language": "eng",
+    "creators": [
+        {
+            "name": "Rath, Willi",
+            "orcid": "0000-0003-1951-8494",
+            "affiliation": "GEOMAR Helmholtz Centre for Ocean Research Kiel"
+        }
+    ],
+    "keywords": [
+        "hexagonal grid",
+        "trajectory analysis",
+        "Lagrangian",
+        "connectivity",
+        "origin-destination matrix",
+        "oceanography",
+        "geospatial",
+        "xarray",
+        "dask",
+        "Python"
+    ],
+    "related_identifiers": [
+        {
+            "identifier": "https://pypi.org/project/hextraj/",
+            "relation": "isIdenticalTo",
+            "resource_type": "software",
+            "scheme": "url"
+        },
+        {
+            "identifier": "https://willirath.github.io/hextraj/",
+            "relation": "isDocumentedBy",
+            "resource_type": "publication-softwaredocumentation",
+            "scheme": "url"
+        }
+    ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "hextraj: hex labelling of trajectory data"
+abstract: >-
+  hextraj maps longitude/latitude positions onto a projected hexagonal grid
+  and provides tools for aggregating trajectory data over hex cells and for
+  computing origin-destination connectivity between them. It operates on
+  NumPy, pandas, xarray, and dask objects, so the same code runs on a single
+  array or on datasets larger than memory.
+type: software
+version: 2026.08.21.1
+date-released: "2026-08-21"
+license: MIT
+authors:
+  - given-names: Willi
+    family-names: Rath
+    email: wrath@geomar.de
+    affiliation: GEOMAR Helmholtz Centre for Ocean Research Kiel
+    orcid: "https://orcid.org/0000-0003-1951-8494"
+repository-code: "https://github.com/willirath/hextraj"
+url: "https://willirath.github.io/hextraj/"
+keywords:
+  - hexagonal grid
+  - trajectory analysis
+  - Lagrangian
+  - connectivity
+  - origin-destination matrix
+  - oceanography
+  - geospatial
+  - xarray
+  - dask


### PR DESCRIPTION
Zenodo is now linked to this repository, so the **next GitHub Release** gets archived and minted a DOI. This PR adds the two files that control what that record looks like.

## What's here

**`.zenodo.json`** — drives the Zenodo record. Per [Zenodo's docs](https://help.zenodo.org/docs/github/describe-software/zenodo-json/), this file takes precedence over `CITATION.cff` and Zenodo ignores it entirely while this exists. It also means the repository `LICENSE` file is no longer auto-detected, so the license is stated explicitly (`"mit"`, lowercase — the Zenodo vocabulary id, not the SPDX one).

Deliberately omits `version`: Zenodo fills that from the release tag, so it can never go stale.

**`CITATION.cff`** — drives GitHub's "Cite this repository" widget, which Zenodo does not touch. Uses SPDX `MIT` and the full ORCID URL, per the CFF 1.2.0 schema.

Both record ORCID `0000-0003-1951-8494` and the GEOMAR affiliation. Single author — every other co-author trailer in the history is a Claude model.

## Maintenance note

`CITATION.cff` pins `version` and `date-released`. Unlike the package version (dynamic via `setuptools_scm`) these do **not** update themselves and need a bump at each release. Dropping them would avoid the chore, but then GitHub's generated citation has no version or year.

## Verification

- `.zenodo.json` parses as JSON; `CITATION.cff` parses as YAML with the expected keys.
- Full test suite passes (209 passed) at this commit.

## Follow-up

The DOI does not exist until the first archived release, so the README badge comes in a separate PR once Zenodo has minted the concept DOI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVcwbWJQjzzstMm9fJq1j
