### PR TITLE
Add Zenodo DOI to README, citation, and PyPI metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -26,6 +26,12 @@
     ],
     "related_identifiers": [
         {
+            "identifier": "https://github.com/willirath/hextraj",
+            "relation": "isSupplementTo",
+            "resource_type": "software",
+            "scheme": "url"
+        },
+        {
             "identifier": "https://pypi.org/project/hextraj/",
             "relation": "isIdenticalTo",
             "resource_type": "software",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,15 +8,20 @@ abstract: >-
   NumPy, pandas, xarray, and dask objects, so the same code runs on a single
   array or on datasets larger than memory.
 type: software
-version: 2026.08.21.1
+version: 2026.08.21.2
 date-released: "2026-08-21"
 license: MIT
+doi: 10.5281/zenodo.22040740
 authors:
   - given-names: Willi
     family-names: Rath
     email: wrath@geomar.de
     affiliation: GEOMAR Helmholtz Centre for Ocean Research Kiel
     orcid: "https://orcid.org/0000-0003-1951-8494"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.22040740
+    description: Concept DOI, resolves to the most recent release
 repository-code: "https://github.com/willirath/hextraj"
 url: "https://willirath.github.io/hextraj/"
 keywords:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/hextraj)](https://pypi.org/project/hextraj/)
 [![License:MIT](https://img.shields.io/badge/License-MIT-lightgray.svg?style=flt-square)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://willirath.github.io/hextraj/)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22040740.svg)](https://doi.org/10.5281/zenodo.22040740)
 
 Hex labelling of trajectory data.
 
@@ -62,3 +63,9 @@ gdf = hp.to_geodataframe(hp.region_of_hexes(region_polygon))
 gdf["count"] = counts.reindex(gdf.index).fillna(0)
 gdf.plot(column="count", cmap="YlOrRd")
 ```
+
+## Citing
+
+Cite hextraj through its DOI. `10.5281/zenodo.22040740` is the concept DOI, and it resolves to the most recent release. Zenodo mints a separate DOI for each release, so use that one to pin an exact version.
+
+[`CITATION.cff`](https://github.com/willirath/hextraj/blob/main/CITATION.cff) holds the same metadata. GitHub renders it as BibTeX or APA under "Cite this repository".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dev  = ["hextraj[full]", "pytest", "pytest-cov"]
 
 [project.urls]
 Homepage = "https://github.com/willirath/hextraj"
+Documentation = "https://willirath.github.io/hextraj/"
+Repository = "https://github.com/willirath/hextraj"
+# Concept DOI: resolves to the most recent Zenodo release.
+DOI = "https://doi.org/10.5281/zenodo.22040740"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Follow-up to #35. Zenodo archived `v2026.08.21.1` and minted the DOIs:

| | DOI |
|---|---|
| **Concept** (resolves to latest release) | [`10.5281/zenodo.22040740`](https://doi.org/10.5281/zenodo.22040740) |
| Version (`v2026.08.21.1`) | [`10.5281/zenodo.22040741`](https://doi.org/10.5281/zenodo.22040741) |

The concept DOI is the one to advertise, so it goes in three places.

## Changes

**`README.md`** — DOI badge plus a `Citing` section. Since `pyproject.toml` sets `readme = "README.md"`, both render on the PyPI project page too. The `CITATION.cff` link is absolute because relative links break once PyPI renders the README outside GitHub.

**`pyproject.toml`** — `Project-URL: DOI` under `[project.urls]`, which puts the DOI in the structured distribution metadata (PyPI sidebar). `Documentation` and `Repository` fill out the same block.

**`CITATION.cff`** — gains `doi` and `identifiers`; version and release date bumped to `2026.08.21.2`.

**`.zenodo.json`** — regains a related identifier pointing at the GitHub repository. Zenodo normally adds that link itself, but a `.zenodo.json` carrying its own `related_identifiers` replaces the automatic one, so the first record shipped without it.

## Verification

Built a wheel and read its `METADATA`. Both routes to PyPI carry the DOI:

```
Project-URL: Homepage, https://github.com/willirath/hextraj
Project-URL: Documentation, https://willirath.github.io/hextraj/
Project-URL: Repository, https://github.com/willirath/hextraj
Project-URL: DOI, https://doi.org/10.5281/zenodo.22040740
```

and the embedded description (`Description-Content-Type: text/markdown`) contains the badge and the `Citing` section.

Test suite: 209 passed.

## Noted, not fixed

The wheel emits an **empty `License:` field** and the project declares no license classifiers, so PyPI shows no license despite the MIT `LICENSE` file. `license = { file = "LICENSE" }` produces only `License-File: LICENSE` under Metadata-Version 2.4. The PEP 639 fix is `license = "MIT"` plus `license-files = ["LICENSE"]`. Out of scope here — happy to do it in a third PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVcwbWJQjzzstMm9fJq1j