### PR TITLE
Fix PyPI license metadata and drop zero-padding from versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@
 - **Discuss before committing** — present what you did and any findings, wait for the go-ahead.
 - Plans go in `dev/plans/*.md`.
 - Agent-facing documentation goes in `dev/docs/*.md`.
+- Releases follow `dev/docs/releasing.md`. Version numbers carry no leading
+  zeros, and a release needs both a tag push and a GitHub release.
 
 ## Environment
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ abstract: >-
   NumPy, pandas, xarray, and dask objects, so the same code runs on a single
   array or on datasets larger than memory.
 type: software
-version: 2026.08.21.2
+version: 2026.8.21.3
 date-released: "2026-08-21"
 license: MIT
 doi: 10.5281/zenodo.22040740

--- a/dev/docs/releasing.md
+++ b/dev/docs/releasing.md
@@ -1,0 +1,61 @@
+# Releasing
+
+## Version numbers
+
+Releases use CalVer in the form `YYYY.M.D.N`. `N` counts releases within a day
+and starts at 1. Tags add a `v` prefix, so a second release on 1 September 2026
+is tagged `v2026.9.1.2`.
+
+Do not pad the month or the day with zeros. PEP 440 strips leading zeros, so a
+tag of `v2026.09.01.2` reaches PyPI as `2026.9.1.2` and the tag stops matching
+the version users see. Tags up to and including `v2026.08.21.2` predate this
+rule and stay as they are.
+
+## Cutting a release
+
+A release is two publishing events. `.github/workflows/release.yml` covers only
+the first one.
+
+1. Bump `version` and `date-released` in `CITATION.cff`, and merge that through
+   a pull request. `setuptools_scm` derives the package version from the git
+   tag, but these two fields are hand-maintained.
+
+2. Push the tag:
+
+   ```shell
+   git tag -a v2026.9.1.1 -m "Release v2026.9.1.1: <summary>"
+   git push origin v2026.9.1.1
+   ```
+
+   The `push: tags: v*` trigger builds the distribution and publishes it to
+   PyPI through a Trusted Publisher.
+
+3. Create the GitHub release from that tag:
+
+   ```shell
+   gh release create v2026.9.1.1 --title v2026.9.1.1 --notes "<notes>"
+   ```
+
+   Zenodo hooks the release event, not the tag push. Skipping this step
+   publishes to PyPI without minting a DOI. A draft release does not trigger
+   Zenodo either.
+
+## Checking the result
+
+Read the Zenodo record back instead of assuming `.zenodo.json` was honoured:
+
+```shell
+curl -s "https://zenodo.org/api/records?q=hextraj&all_versions=true" \
+    | python -m json.tool
+```
+
+Confirm `license`, `creators`, and `related_identifiers`. `.zenodo.json` takes
+precedence over `CITATION.cff`, and it suppresses the license and the
+repository link that Zenodo otherwise detects on its own.
+
+## DOIs
+
+Concept DOI `10.5281/zenodo.22040740` resolves to the most recent release.
+Zenodo mints a separate DOI for each release. `README.md`, `CITATION.cff`, and
+`[project.urls]` all record the concept DOI, so none of them needs an update
+per release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -15,9 +15,31 @@ name = "hextraj"
 dynamic = ["version"]
 description = "Hex labelling of trajectory data"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Willi Rath", email = "wrath@geomar.de" }]
 requires-python = ">=3.10"
+keywords = [
+    "hexagonal grid",
+    "trajectory analysis",
+    "connectivity",
+    "oceanography",
+    "geospatial",
+    "xarray",
+    "dask",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Scientific/Engineering :: Oceanography",
+]
 dependencies = [
     "numpy",
     "pyproj",


### PR DESCRIPTION
Two fixes flagged in #36.

## PyPI showed no license

`license = { file = "LICENSE" }` emits only `License-File:` under Metadata-Version 2.4 and leaves `License:` empty, so PyPI displayed no license despite the MIT `LICENSE` file. The project also declared no classifiers at all.

- `license = "MIT"` + `license-files = ["LICENSE"]` (PEP 639) → emits `License-Expression: MIT`
- `build-system.requires` moves `setuptools>=64` → `setuptools>=77`, which PEP 639 needs
- Classifiers and keywords added

Two deliberate omissions: **no license classifier** (PEP 639 deprecates it and setuptools rejects the pair), and **no `Typing :: Typed`** (the package ships no `py.typed`, so type checkers would ignore it anyway). All classifiers checked against the live trove list.

## Versions drop the zero padding

PEP 440 strips leading zeros, so tag `v2026.08.21.2` reached PyPI as `2026.8.21.2` — the tag stopped matching the version users see. Next release is `v2026.8.21.3`. Existing tags predate the rule and stay as they are.

`dev/docs/releasing.md` (new) records the convention and both halves of a release. `release.yml` only covers the PyPI half, and nothing in the repo stated that creating a **GitHub release** is what triggers Zenodo — a tag push alone mints no DOI. `AGENTS.md` points at it.

## Verification

Built wheel and sdist:

```
Metadata-Version: 2.4
License-Expression: MIT
Keywords: hexagonal grid,trajectory analysis,connectivity,oceanography,geospatial,xarray,dask
Classifier: Development Status :: 4 - Beta
...
Classifier: Topic :: Scientific/Engineering :: Oceanography
License-File: LICENSE
```

LICENSE bundled at `dist-info/licenses/LICENSE`. `twine check` passes on both artifacts. Test suite: 209 passed.

## Note

This is inert until published — the license only appears on PyPI once a release goes out under the new metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVcwbWJQjzzstMm9fJq1j