### PR TITLE
Add test CI, redblobhex parity tests, and status badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # setuptools_scm derives the version from git history.
+          fetch-depth: 0
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          environments: default
+          locked: false
+
+      - name: Run tests
+        run: pixi run test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # hextraj
 
+[![Tests](https://github.com/willirath/hextraj/actions/workflows/tests.yml/badge.svg)](https://github.com/willirath/hextraj/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/hextraj)](https://pypi.org/project/hextraj/)
-[![License:MIT](https://img.shields.io/badge/License-MIT-lightgray.svg?style=flt-square)](LICENSE)
+[![Python](https://img.shields.io/pypi/pyversions/hextraj)](https://pypi.org/project/hextraj/)
+[![License:MIT](https://img.shields.io/badge/License-MIT-lightgray.svg?style=flt-square)](https://github.com/willirath/hextraj/blob/main/LICENSE)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://willirath.github.io/hextraj/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22040740.svg)](https://doi.org/10.5281/zenodo.22040740)
 

--- a/dev/docs/releasing.md
+++ b/dev/docs/releasing.md
@@ -11,6 +11,18 @@ tag of `v2026.09.01.2` reaches PyPI as `2026.9.1.2` and the tag stops matching
 the version users see. Tags up to and including `v2026.08.21.2` predate this
 rule and stay as they are.
 
+## When to release
+
+Release when a change reaches users. That means `src/hextraj/`, or packaging
+metadata in `pyproject.toml` that PyPI displays.
+
+`README.md` reaches users too, because `readme = "README.md"` makes it the PyPI
+long description. A README-only change rides along with the next release rather
+than earning one of its own.
+
+Changes under `dev/`, `tests/`, and `.github/` never reach users, so they call
+for no release at all. Let them accumulate on `main`.
+
 ## Cutting a release
 
 A release is two publishing events. `.github/workflows/release.yml` covers only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,14 @@ minversion = "6.0"
 addopts = "-v"
 testpaths = ["tests"]
 
+[tool.coverage.run]
+source = ["src/hextraj"]
+# Vendored hex math from redblobgames.com (CC0). Excluded from mypy too.
+omit = ["*/hextraj/redblobhex.py", "*/hextraj/redblobhex_array.py"]
+
+[tool.coverage.report]
+show_missing = true
+
 [tool.mypy]
 ignore_missing_imports = true
 exclude = ["src/hextraj/redblobhex\\.py", "src/hextraj/redblobhex_array\\.py"]

--- a/tests/test_hex_analysis.py
+++ b/tests/test_hex_analysis.py
@@ -7,7 +7,12 @@ from shapely.geometry import LineString, Polygon
 
 from hextraj.hexproj import HexProj
 from hextraj.hex_id import INVALID_HEX_ID
-from hextraj.hex_analysis import hex_counts, hex_connectivity, hex_connectivity_power
+from hextraj.hex_analysis import (
+    hex_counts,
+    hex_counts_lazy,
+    hex_connectivity,
+    hex_connectivity_power,
+)
 
 
 @pytest.fixture
@@ -432,3 +437,17 @@ def test_hex_connectivity_power_condition_drops_invalid_column(hex_ids_invalid, 
     to_ids = result.index.get_level_values("to_id")
     assert INVALID_HEX_ID not in from_ids
     assert INVALID_HEX_ID not in to_ids
+
+
+def test_hex_counts_lazy_rejects_unsupported_type():
+    """Anything other than a DataArray or Series must raise, not coerce."""
+    with pytest.raises(TypeError, match="must be xr.DataArray"):
+        hex_counts_lazy(np.array([1, 2, 3]))
+
+
+def test_hex_counts_lazy_accepts_reduce_dims_as_string(hex_ids):
+    """A bare dim name means the same as a one-element list."""
+    from_string = hex_counts_lazy(hex_ids, reduce_dims="obs")
+    from_list = hex_counts_lazy(hex_ids, reduce_dims=["obs"])
+
+    assert from_string.equals(from_list)

--- a/tests/test_hexproj.py
+++ b/tests/test_hexproj.py
@@ -66,3 +66,34 @@ def test_check_orientations_available():
     hp_pointy = HexProj(hex_orientation="pointy")
     with pytest.raises(ValueError, match="Only 'flat' and 'pointy'"):
         hp_nonexistent = HexProj(hex_orientation="nonexistent")
+
+
+@pytest.mark.parametrize("orientation", ["flat", "pointy"])
+def test_hex_corners_lon_lat_returns_closed_ring_of_seven(orientation):
+    """The seventh corner repeats the first so the polygon closes."""
+    hex_proj = HexProj(
+        lon_origin=0,
+        lat_origin=0,
+        hex_size_meters=100_000,
+        hex_orientation=orientation,
+    )
+    corners = hex_proj.hex_corners_lon_lat(Hex(0, 0, 0))
+
+    assert len(corners) == 7
+    # Closes to floating-point precision rather than exactly.
+    assert np.allclose(corners[0], corners[-1])
+
+
+@pytest.mark.parametrize("orientation", ["flat", "pointy"])
+def test_hex_corners_lon_lat_surround_the_origin(orientation):
+    """The origin hex is centred on (lon_origin, lat_origin)."""
+    hex_proj = HexProj(
+        lon_origin=0,
+        lat_origin=0,
+        hex_size_meters=100_000,
+        hex_orientation=orientation,
+    )
+    lons, lats = np.array(hex_proj.hex_corners_lon_lat(Hex(0, 0, 0))).T
+
+    assert lons.min() < 0.0 < lons.max()
+    assert lats.min() < 0.0 < lats.max()

--- a/tests/test_redblobhex_parity.py
+++ b/tests/test_redblobhex_parity.py
@@ -1,0 +1,146 @@
+"""Pin the numpy hex math to the vendored scalar reference.
+
+``redblobhex.py`` is generated code from redblobgames.com and is never
+imported by hextraj. ``redblobhex_array.py`` is a hand-written numpy port
+of it, and every module uses that port instead. These tests keep the two
+in agreement, so a change to the port that drifts from the reference
+fails here.
+
+Each test feeds one vectorised call and the equivalent loop of scalar
+calls the same inputs, which checks the port and its vectorisation
+together.
+"""
+
+import numpy as np
+import pytest
+
+from hextraj import redblobhex as scalar
+from hextraj import redblobhex_array as arr
+
+
+ORIENTATIONS = [
+    ("pointy", scalar.layout_pointy, arr.orientation_pointy),
+    ("flat", scalar.layout_flat, arr.orientation_flat),
+]
+
+# Axial coordinates covering both signs, an origin hex, and a long jump.
+QR = [(0, 0), (1, 0), (0, 1), (-1, 2), (3, -2), (5, 5), (-4, -4), (12, -7)]
+
+# Fractional hexes for rounding. The last three sit on a half-way tie,
+# where Python's round() and numpy's round() must agree on round-half-even.
+QR_FRACTIONAL = [
+    (0.2, -0.1),
+    (1.4, 0.3),
+    (-2.6, 1.1),
+    (3.49, -1.51),
+    (0.5, 0.25),
+    (1.5, -0.5),
+    (2.5, 0.5),
+]
+
+SIZE = (50_000.0, 50_000.0)
+ORIGIN = (0.0, 0.0)
+
+
+def _layouts(scalar_orientation, array_orientation):
+    """Build the matching scalar and array layout for one orientation."""
+    return (
+        scalar.Layout(scalar_orientation, scalar.Point(*SIZE), scalar.Point(*ORIGIN)),
+        arr.Layout(array_orientation, arr.Point(*SIZE), arr.Point(*ORIGIN)),
+    )
+
+
+@pytest.mark.parametrize("name,scalar_orientation,array_orientation", ORIENTATIONS)
+def test_orientation_constants_match(name, scalar_orientation, array_orientation):
+    fields = ["f0", "f1", "f2", "f3", "b0", "b1", "b2", "b3", "start_angle"]
+    for field in fields:
+        assert getattr(array_orientation, field) == pytest.approx(
+            getattr(scalar_orientation, field)
+        ), f"{name}.{field} drifted from the reference"
+
+
+@pytest.mark.parametrize("name,scalar_orientation,array_orientation", ORIENTATIONS)
+def test_hex_to_pixel_matches_scalar(name, scalar_orientation, array_orientation):
+    scalar_layout, array_layout = _layouts(scalar_orientation, array_orientation)
+    q = np.array([qq for qq, _ in QR], dtype=float)
+    r = np.array([rr for _, rr in QR], dtype=float)
+
+    got = arr.hex_to_pixel(array_layout, arr.Hex(q, r, -q - r))
+    expected = [
+        scalar.hex_to_pixel(scalar_layout, scalar.Hex(float(qq), float(rr), float(-qq - rr)))
+        for qq, rr in QR
+    ]
+
+    np.testing.assert_allclose(got.x, [p.x for p in expected])
+    np.testing.assert_allclose(got.y, [p.y for p in expected])
+
+
+@pytest.mark.parametrize("name,scalar_orientation,array_orientation", ORIENTATIONS)
+def test_pixel_to_hex_matches_scalar(name, scalar_orientation, array_orientation):
+    scalar_layout, array_layout = _layouts(scalar_orientation, array_orientation)
+    # Offset off the hex centres so the fractional coordinates are non-trivial.
+    xs = np.array([qq * 13_000.0 + 700.0 for qq, _ in QR])
+    ys = np.array([rr * 11_000.0 - 400.0 for _, rr in QR])
+
+    got = arr.pixel_to_hex(array_layout, arr.Point(xs, ys))
+    expected = [
+        scalar.pixel_to_hex(scalar_layout, scalar.Point(float(x), float(y)))
+        for x, y in zip(xs, ys)
+    ]
+
+    np.testing.assert_allclose(got.q, [h.q for h in expected])
+    np.testing.assert_allclose(got.r, [h.r for h in expected])
+    np.testing.assert_allclose(got.s, [h.s for h in expected])
+
+
+@pytest.mark.parametrize("name,scalar_orientation,array_orientation", ORIENTATIONS)
+@pytest.mark.parametrize("corner", range(7))
+def test_hex_corner_offset_matches_scalar(
+    name, scalar_orientation, array_orientation, corner
+):
+    scalar_layout, array_layout = _layouts(scalar_orientation, array_orientation)
+
+    got = arr.hex_corner_offset(array_layout, corner)
+    expected = scalar.hex_corner_offset(scalar_layout, corner)
+
+    assert got.x == pytest.approx(expected.x)
+    assert got.y == pytest.approx(expected.y)
+
+
+def test_hex_round_matches_scalar():
+    q = np.array([qq for qq, _ in QR_FRACTIONAL], dtype=float)
+    r = np.array([rr for _, rr in QR_FRACTIONAL], dtype=float)
+
+    got = arr.hex_round(arr.Hex(q, r, -q - r))
+    expected = [
+        scalar.hex_round(scalar.Hex(float(qq), float(rr), float(-qq - rr)))
+        for qq, rr in QR_FRACTIONAL
+    ]
+
+    np.testing.assert_array_equal(got.q, [h.q for h in expected])
+    np.testing.assert_array_equal(got.r, [h.r for h in expected])
+    np.testing.assert_array_equal(got.s, [h.s for h in expected])
+
+
+def test_hex_round_result_stays_on_the_cube_plane():
+    q = np.array([qq for qq, _ in QR_FRACTIONAL], dtype=float)
+    r = np.array([rr for _, rr in QR_FRACTIONAL], dtype=float)
+
+    got = arr.hex_round(arr.Hex(q, r, -q - r))
+
+    np.testing.assert_array_equal(got.q + got.r + got.s, np.zeros_like(got.q))
+
+
+@pytest.mark.parametrize("name,scalar_orientation,array_orientation", ORIENTATIONS)
+def test_pixel_to_hex_round_trips_through_hex_to_pixel(
+    name, scalar_orientation, array_orientation
+):
+    _, array_layout = _layouts(scalar_orientation, array_orientation)
+    q = np.array([qq for qq, _ in QR], dtype=float)
+    r = np.array([rr for _, rr in QR], dtype=float)
+
+    pixels = arr.hex_to_pixel(array_layout, arr.Hex(q, r, -q - r))
+    back = arr.hex_round(arr.pixel_to_hex(array_layout, pixels))
+
+    np.testing.assert_array_equal(back.q, q.astype(int))
+    np.testing.assert_array_equal(back.r, r.astype(int))


### PR DESCRIPTION
Four files, 188 lines. Closes the CI gap noted after #37.

## Test CI

Nothing ran the suite on a pull request — `.github/workflows/` had only `docs.yml` and `release.yml`. `tests.yml` runs `pixi run test` on pushes to main and on every PR, reusing the docs workflow's pixi setup. `fetch-depth: 0` because `setuptools_scm` needs history for the editable install.

## redblobhex parity tests

`redblobhex.py` is generated reference code from redblobgames.com that **no module imports** — every import site resolves `redblobhex` to `redblobhex_array`:

```python
from . import redblobhex_array as redblobhex   # hexproj.py:14, hex_analysis.py:14
```

So the reference sat unused and the numpy port had nothing pinning it to upstream. `tests/test_redblobhex_parity.py` (24 tests) compares one **vectorised** call against the equivalent loop of **scalar** calls, which checks the port and its vectorisation together:

- `hex_to_pixel`, `pixel_to_hex`, `hex_corner_offset`, `hex_round`
- the pointy and flat orientation constants
- a `hex_to_pixel` → `pixel_to_hex` → `hex_round` round trip
- `hex_round` output staying on the `q + r + s == 0` plane

The rounding cases include half-way ties (`0.5`, `1.5`, `2.5`), where Python's `round` and `np.round` both have to round half to even. **They agree** — no divergence found.

## Coverage now measures first-party code only

It was counting the test files themselves, inflating the total, and reporting nothing at all for the vendored modules. `[tool.coverage.run]` scopes to `src/hextraj` and omits the two vendored files, matching the existing `[tool.mypy]` exclude.

| | before | after |
|---|---|---|
| reported | 98% over 1467 stmts (tests included) | **97% over 361 stmts** |

## Badges

Tests status, plus a Python-versions badge that reads the classifiers added in #37. The license badge link becomes absolute — relative links break when PyPI renders the README.

## Verification

233 passed (209 existing + 24 new).

## Coverage gaps closed

Folded in after review:

- **`hexproj.hex_corners_lon_lat`** — public, previously untested. Two tests over both orientations: the ring is seven corners and closes, and the corners straddle the origin. The ring closes to floating-point precision, not exactly, so the assertion uses `np.allclose` where the docstring claims "identical".
- **`hex_counts_lazy`** — the `TypeError` guard on unsupported input, and a bare dim name behaving as a one-element list.

| | before | after |
|---|---|---|
| first-party coverage | 97% | **99%** |
| `hexproj.py` | 97% | **100%** |

What remains is the dask branch of `hex_connectivity` when `weight=None` (5 statements). That needs a dask fixture, not a one-liner.

## When to release

`dev/docs/releasing.md` gains a "When to release" section. The repo documented *how* to release but never *when*, and three of today's releases carried no code. Changes under `dev/`, `tests/`, and `.github/` reach no user and need no release — including this PR.

## Verification

239 passed. Tests CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVcwbWJQjzzstMm9fJq1j
