### PR TITLE
Close hex polygon rings exactly

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ abstract: >-
   NumPy, pandas, xarray, and dask objects, so the same code runs on a single
   array or on datasets larger than memory.
 type: software
-version: 2026.8.21.3
+version: 2026.8.21.4
 date-released: "2026-08-21"
 license: MIT
 doi: 10.5281/zenodo.22040740

--- a/src/hextraj/hexproj.py
+++ b/src/hextraj/hexproj.py
@@ -73,8 +73,13 @@ class HexProj:
         )
 
         corner_offsets = tuple(
-            redblobhex.hex_corner_offset(self.hex_layout_projected, c) for c in range(7)
+            redblobhex.hex_corner_offset(self.hex_layout_projected, c) for c in range(6)
         )
+        # Close the ring with an exact copy of the first corner. Recomputing it as
+        # corner 6 shifts the angle by 2*pi, which sin and cos do not undo exactly.
+        # Shapely then misses that the ring is closed and appends a vertex, leaving
+        # a zero-length edge on every polygon.
+        corner_offsets += (corner_offsets[0],)
         self.corner_offsets_projected = corner_offsets
         self.corner_offsets_x = np.array([p.x for p in corner_offsets])
         self.corner_offsets_y = np.array([p.y for p in corner_offsets])

--- a/tests/test_hexproj.py
+++ b/tests/test_hexproj.py
@@ -80,8 +80,7 @@ def test_hex_corners_lon_lat_returns_closed_ring_of_seven(orientation):
     corners = hex_proj.hex_corners_lon_lat(Hex(0, 0, 0))
 
     assert len(corners) == 7
-    # Closes to floating-point precision rather than exactly.
-    assert np.allclose(corners[0], corners[-1])
+    assert corners[0] == corners[-1]
 
 
 @pytest.mark.parametrize("orientation", ["flat", "pointy"])
@@ -97,3 +96,40 @@ def test_hex_corners_lon_lat_surround_the_origin(orientation):
 
     assert lons.min() < 0.0 < lons.max()
     assert lats.min() < 0.0 < lats.max()
+
+
+@pytest.mark.parametrize("orientation", ["flat", "pointy"])
+def test_hex_corner_offsets_close_the_ring_exactly(orientation):
+    """The closing offset must be bit-identical to the first, not recomputed."""
+    hex_proj = HexProj(
+        lon_origin=0,
+        lat_origin=0,
+        hex_size_meters=100_000,
+        hex_orientation=orientation,
+    )
+
+    assert hex_proj.corner_offsets_x[0] == hex_proj.corner_offsets_x[-1]
+    assert hex_proj.corner_offsets_y[0] == hex_proj.corner_offsets_y[-1]
+
+
+@pytest.mark.parametrize("orientation", ["flat", "pointy"])
+def test_to_geodataframe_polygons_have_no_degenerate_vertex(orientation):
+    """A closed hexagon is seven coordinates; an eighth means a degenerate edge.
+
+    Shapely appends a closing vertex when the last coordinate does not
+    equal the first exactly, which leaves a zero-length edge behind.
+    """
+    hex_proj = HexProj(
+        lon_origin=0,
+        lat_origin=0,
+        hex_size_meters=100_000,
+        hex_orientation=orientation,
+    )
+    hex_ids = hex_proj.label(
+        np.array([0.0, 5.0, -12.0, 30.0]), np.array([0.0, 40.0, -33.0, 60.0])
+    )
+
+    for geom in hex_proj.to_geodataframe(hex_ids).geometry:
+        coords = np.asarray(geom.exterior.coords)
+        assert len(coords) == 7
+        assert np.array_equal(coords[0], coords[-1])


### PR DESCRIPTION
Good catch on the 2e-16 — it was not test-precision noise. It was a real defect in every polygon the library emits.

## The bug

`HexProj.__init__` built its seven corner offsets by calling `hex_corner_offset` for `range(7)`. Corner 6 has the same angle as corner 0 shifted by `2*pi`, and sine/cosine do not undo that shift exactly:

```
corner_offsets_y[0] = 0.0
corner_offsets_y[6] = 2.4492935982947064e-11     # metres
```

So the last vertex never equalled the first. Shapely could not see the ring as closed, appended a copy of the first vertex, and every hexagon came out with **eight** coordinates and a zero-length edge:

```
  6: 0.8983244852644348   2.2149983069031495e-16   <- computed corner 6
  7: 0.8983244852644348   0.0                      <- appended by shapely
```

This affected **every polygon from `to_geodataframe`**, so every `hex_counts` GeoDataFrame too — not just the `hex_corners_lon_lat` list where I first noticed it. Both orientations.

## The fix

Compute six corners and close the ring with an exact copy of the first:

```python
corner_offsets = tuple(
    redblobhex.hex_corner_offset(self.hex_layout_projected, c) for c in range(6)
)
corner_offsets += (corner_offsets[0],)
```

Both consumers read the same offsets, so `to_geodataframe` and `hex_corners_lon_lat` are fixed together. Identical projected inputs give identical inverse-projection outputs, so the closure survives the transform.

This also makes the `hex_corners_lon_lat` docstring true — it already claimed the first and last corners are identical.

## Tests

Written first, confirmed failing on both orientations before the fix:

- `test_hex_corner_offsets_close_the_ring_exactly` — the closing offset is bit-identical to the first
- `test_to_geodataframe_polygons_have_no_degenerate_vertex` — each exterior ring has exactly 7 coordinates, first equal to last

The existing closure test tightens from `np.allclose` to `==`, since exactness is the actual contract.

Verified after the fix: 7 coordinates per polygon, `is_valid` true, non-zero area, both orientations.

## Result

243 passed. Coverage holds at 99%, `hexproj.py` at 100%.

## Release

This changes `src/hextraj/`, so per the "When to release" policy added in #38 it does warrant a release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjVcwbWJQjzzstMm9fJq1j